### PR TITLE
fix: errors name the platform using just architecture and os

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -1,0 +1,78 @@
+name: Native Gems
+on: [push, pull_request]
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ["ruby", "x64-mingw32", "x86_64-darwin", "x86_64-linux"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+          bundler: latest
+          bundler-cache: true
+      - run: "rake gem:${{matrix.platform}}"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: gem-${{matrix.platform}}
+          path: pkg
+          retention-days: 1
+
+  vanilla-install:
+    needs: ["package"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+      - uses: actions/download-artifact@v2
+        with:
+          name: gem-ruby
+          path: pkg
+      - run: "gem install pkg/sprockets-esbuild-*.gem"
+      - run: "esbuild 2>&1 | fgrep 'ERROR: Cannot find the esbuild executable'"
+
+  linux-install:
+    needs: ["package"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+      - uses: actions/download-artifact@v2
+        with:
+          name: gem-x86_64-linux
+          path: pkg
+      - run: "gem install pkg/sprockets-esbuild-*.gem"
+      - run: "esbuild --help"
+
+  darwin-install:
+    needs: ["package"]
+    runs-on: macos-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+      - uses: actions/download-artifact@v2
+        with:
+          name: gem-x86_64-darwin
+          path: pkg
+      - run: "gem install pkg/sprockets-esbuild-*.gem"
+      - run: "esbuild --help"
+
+  windows-install:
+    needs: ["package"]
+    runs-on: windows-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+      - uses: actions/download-artifact@v2
+        with:
+          name: gem-x64-mingw32
+          path: pkg
+      - run: "gem install pkg/sprockets-esbuild-*.gem"
+      - run: "esbuild --help"

--- a/exe/esbuild
+++ b/exe/esbuild
@@ -5,10 +5,11 @@ require "shellwords"
 require "sprockets-esbuild/upstream"
 
 supported_platforms = SprocketsEsbuild::Upstream::NATIVE_PLATFORMS.keys
+platform = [:cpu, :os].map { |m| Gem::Platform.local.send(m) }.join("-")
 
 if supported_platforms.none? { |supported_platform| Gem::Platform.match(supported_platform) }
   STDERR.puts(<<~ERRMSG)
-    ERROR: sprockets-esbuild does not support the #{::Gem::Platform.local} platform
+    ERROR: sprockets-esbuild does not support the #{platform} platform
   ERRMSG
   exit 1
 end
@@ -18,7 +19,7 @@ exe_path = Dir.glob(File.join(__dir__, "*", "esbuild")).find do |f|
 end
 if exe_path.nil?
   STDERR.puts(<<~ERRMSG)
-    ERROR: Cannot find the esbuild executable for #{::Gem::Platform.local} in #{__dir__}
+    ERROR: Cannot find the esbuild executable for #{platform} in #{__dir__}
     If you're using bundler, please make sure you're on the latest bundler version:
 
       gem install bundler
@@ -26,7 +27,7 @@ if exe_path.nil?
 
     Then make sure your lock file includes this platform by running:
 
-      bundle lock --add-platform #{::Gem::Platform.local}
+      bundle lock --add-platform #{platform}
       bundle install
 
     See `bundle lock --help` output for details.


### PR DESCRIPTION
On darwin this means the error messages and bundler instructions will
name, e.g., "x86_64-darwin" without the OS version. This makes the
bundler lock file as general as possible.

Previously the platform name included the OS version,
e.g. "x86_64-darwin-21" which is unnecessarily specific for this gem