### PR TITLE
fix: pick the windows executable out of the npm tarball

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -1,5 +1,14 @@
 name: Native Gems
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - '*'
+
 jobs:
   package:
     strategy:

--- a/lib/sprockets-esbuild/upstream.rb
+++ b/lib/sprockets-esbuild/upstream.rb
@@ -3,12 +3,12 @@ module SprocketsEsbuild
   module Upstream
     VERSION = "0.14.5"
 
-    # rubygems platform name => upstream release filename
+    # rubygems platform name => [upstream release tarball name, tarball path]
     NATIVE_PLATFORMS = {
-      "arm64-darwin" => "esbuild-darwin-arm64",
-      "x64-mingw32" => "esbuild-windows-64",
-      "x86_64-darwin" => "esbuild-darwin-64",
-      "x86_64-linux" => "esbuild-linux-64",
+      "arm64-darwin" => ["esbuild-darwin-arm64", "package/bin/esbuild"],
+      "x64-mingw32" => ["esbuild-windows-64", "package/esbuild.exe"],
+      "x86_64-darwin" => ["esbuild-darwin-64", "package/bin/esbuild"],
+      "x86_64-linux" => ["esbuild-linux-64", "package/bin/esbuild"],
     }
   end
 end

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -69,7 +69,9 @@ desc "Build the ruby gem"
 task "gem:ruby" => [gem_path]
 
 exepaths = []
-SprocketsEsbuild::Upstream::NATIVE_PLATFORMS.each do |platform, filename|
+SprocketsEsbuild::Upstream::NATIVE_PLATFORMS.each do |platform, filenames|
+  filename = filenames.first
+  tarpath = filenames.last
   ESBUILD_RAILS_GEMSPEC.dup.tap do |gemspec|
     exedir = File.join(gemspec.bindir, platform) # "exe/x86_64-linux"
     exepath = File.join(exedir, "esbuild") # "exe/x86_64-linux/esbuild"
@@ -96,8 +98,8 @@ SprocketsEsbuild::Upstream::NATIVE_PLATFORMS.each do |platform, filename|
         end
       end
 
-      sh "tar xzf #{exepath}.tgz package/bin/esbuild"
-      mv 'package/bin/esbuild', exepath
+      sh "tar xzf #{exepath}.tgz #{tarpath}"
+      mv tarpath, exepath
       rm_rf "#{exepath}.tgz"
       rm_rf 'package'
       FileUtils.chmod(0755, exepath, verbose: true)


### PR DESCRIPTION
Fixes #2 

The windows tarball includes these files:

```
$ tar ztvf exe/x64-mingw32/esbuild.tgz
-rwxr-xr-x 0/0             758 1985-10-26 04:15 package/bin/esbuild
-rwxr-xr-x 0/0         7924224 1985-10-26 04:15 package/esbuild.exe
-rw-r--r-- 0/0             292 1985-10-26 04:15 package/package.json
-rw-r--r-- 0/0             143 1985-10-26 04:15 package/README.md
```

In the windows tarball specifically, the `package/bin/esbuild` file is a node script that runs `package/esbuild.exe`.

This PR picks the exe directly.