### PR TITLE
replace call to shellwords with a call to system passing an array

### DIFF
--- a/exe/esbuild
+++ b/exe/esbuild
@@ -1,7 +1,6 @@
 #! /usr/bin/env ruby
 # because rubygems shims assume a gem's executables are Ruby
 
-require "shellwords"
 require "sprockets-esbuild/upstream"
 
 supported_platforms = SprocketsEsbuild::Upstream::NATIVE_PLATFORMS.keys
@@ -35,5 +34,4 @@ if exe_path.nil?
   exit 1
 end
 
-command = Shellwords.join([exe_path, ARGV].flatten)
-exec(command)
+system exe_path, *ARGV


### PR DESCRIPTION
[Shellwords](https://ruby-doc.org/stdlib-3.0.2/libdoc/shellwords/rdoc/Shellwords.html) is not compatible with Windows.

While `--help` works, other common esbuild options do not, for example:

```
Shellwords.escape('--loader=ts')
=> "--loader\\=ts"
```

The most obvious fix, namely calling [exec](https://apidock.com/ruby/Kernel/exec) with an array of arguments curiously fails on windows with an error of the executable not being found.  

Surprisingly, the exact same invocation using `system` instead of `exec` works.